### PR TITLE
remove view restriction for some apis because defi contract functions…

### DIFF
--- a/contracts/strategies/AbstractStrategy.sol
+++ b/contracts/strategies/AbstractStrategy.sol
@@ -41,7 +41,7 @@ abstract contract AbstractStrategy is IStrategy, Ownable {
     /**
      * @return The underlying asset amount of the supply token with 18 decimals
      */
-    function getAssetAmount() public view virtual returns (uint256);
+    function getAssetAmount() internal virtual returns (uint256);
 
     /**
      * @notice Buys lp token from defi contract
@@ -127,7 +127,7 @@ abstract contract AbstractStrategy is IStrategy, Ownable {
         return redeemedUnderlyingAsset;
     }
 
-    function syncPrice() external view override returns (uint256) {
+    function syncPrice() external override returns (uint256) {
         uint256 assetAmount = getAssetAmount();
         if (shares == 0) {
             if (assetAmount == 0) {


### PR DESCRIPTION
… that might be used in those functions are not necessarily views; change getAssetAmount to internal as it's not used publicly